### PR TITLE
Fix no fires messaging

### DIFF
--- a/activefires_pp/post_processing.py
+++ b/activefires_pp/post_processing.py
@@ -426,9 +426,10 @@ class ActiveFiresPostprocessing(Thread):
                     continue
 
                 file_ok = check_file_type_okay(msg.data.get('type'))
-                output_messages = self._generate_no_fires_messages(msg, 'No fire detections for this granule')
+                no_fires_text = 'No fire detections for this granule'
+                output_messages = self._generate_no_fires_messages(msg, no_fires_text)
                 if not file_ok:
-                    for outout_msg in output_messages:
+                    for output_msg in output_messages:
                         logger.debug("Sending message: %s", str(output_msg))
                         self.publisher.send(str(output_msg))
                     continue

--- a/activefires_pp/post_processing.py
+++ b/activefires_pp/post_processing.py
@@ -558,13 +558,13 @@ class ActiveFiresPostprocessing(Thread):
         pubmsg = Message(output_topic, 'file', to_send)
         return pubmsg
 
-    def _generate_no_fires_messages(self, input_msg, msg_string)
-    """Create the output messages to publish."""
+    def _generate_no_fires_messages(self, input_msg, msg_string):
+        """Create the output messages to publish."""
 
-    to_send = prepare_posttroll_message(input_msg)
-     to_send['info'] = msg_string
-      publish_messages = []
-       for ext in ['National', 'Regional']:
+        to_send = prepare_posttroll_message(input_msg)
+        to_send['info'] = msg_string
+        publish_messages = []
+        for ext in ['National', 'Regional']:
             topic = self.output_topic + '/' + ext
             publish_messages.append(Message(topic, 'info', to_send))
 

--- a/activefires_pp/tests/test_fires_filtering.py
+++ b/activefires_pp/tests/test_fires_filtering.py
@@ -274,9 +274,9 @@ def test_general_national_fires_filtering(get_global_mask, setup_comm, get_confi
     mymsg = "Fake message"
 
     with patch('activefires_pp.post_processing.store_geojson') as store_geojson:
-        with patch('activefires_pp.post_processing.ActiveFiresPostprocessing.get_output_message') as get_output_msg:
+        with patch('activefires_pp.post_processing.ActiveFiresPostprocessing.get_output_messages') as get_output_msg:
             store_geojson.return_value = "/some/output/path"
-            get_output_msg.return_value = "my fake output message"
+            get_output_msg.return_value = ["my fake output message"]
             outmsg, result = afpp.fires_filtering(mymsg, af_shapeff)
 
     store_geojson.assert_called_once()
@@ -287,4 +287,4 @@ def test_general_national_fires_filtering(get_global_mask, setup_comm, get_confi
     assert len(result) == 1
     np.testing.assert_almost_equal(result.iloc[0]['latitude'], 59.52483368)
     np.testing.assert_almost_equal(result.iloc[0]['longitude'], 17.1681633)
-    assert outmsg == "my fake output message"
+    assert outmsg == ["my fake output message"]

--- a/activefires_pp/tests/test_messaging.py
+++ b/activefires_pp/tests/test_messaging.py
@@ -61,7 +61,6 @@ def test_prepare_posttroll_message(setup_comm, get_config, gethostname):
     myconfigfile = "/my/config/file/path"
     myboarders_file = "/my/shape/file/with/country/boarders"
     mymask_file = "/my/shape/file/with/polygons/to/filter/out"
-    #myregion_filepath = "/my/region/file/path"
 
     afpp = ActiveFiresPostprocessing(myconfigfile, myboarders_file, mymask_file)
 
@@ -86,11 +85,13 @@ def test_prepare_posttroll_message(setup_comm, get_config, gethostname):
     assert res_msg.subject == '/VIIRS/L2/Fires/PP/Regional/9999'
 
     msg_str = 'No fire detections for this granule'
-    res_msg = afpp._generate_no_fires_message(input_msg, msg_str)
 
-    assert res_msg.data['info'] == msg_str
-    assert res_msg.subject == '/VIIRS/L2/Fires/PP'
-    assert 'type' not in res_msg.data
-    assert 'format' not in res_msg.data
-    assert 'product' not in res_msg.data
-    assert 'uri' not in res_msg.data
+    result_messages = afpp._generate_no_fires_messages(input_msg, msg_str)
+
+    for (nat_or_reg, res_msg) in zip(['National', 'Regional'], result_messages):
+        assert res_msg.data['info'] == msg_str
+        assert res_msg.subject == '/VIIRS/L2/Fires/PP/' + nat_or_reg
+        assert 'type' not in res_msg.data
+        assert 'format' not in res_msg.data
+        assert 'product' not in res_msg.data
+        assert 'uri' not in res_msg.data


### PR DESCRIPTION
Send messages also when no fires are detected - and send using the two topics for Regional and National filtering, so that downstream the notification processes will receive messages at all granules received and processed through to EDR level.
This will enable for an easier way of setting up passive monitoring with NAGIOS type of monitoring systems. 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
