### PR TITLE
Make thresholds configurable

### DIFF
--- a/activefires_pp/geojson_utils.py
+++ b/activefires_pp/geojson_utils.py
@@ -20,8 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Geojson utilities.
-"""
+"""Geojson utilities."""
 
 import geojson
 import json
@@ -47,7 +46,7 @@ def read_geojson_data(filename):
         LOG.error("No valid filename to read: %s", str(filename))
 
 
-def get_recent_geojson_files(path, pattern, time_interval):
+def get_geojson_files_in_observation_time_order(path, pattern, time_interval):
     """Get all geojson files with filtered active fire detections (=triggered alarms) since *dtime*."""
     dtime_start = time_interval[0]
     dtime_end = time_interval[1]

--- a/activefires_pp/spatiotemporal_alarm_filtering.py
+++ b/activefires_pp/spatiotemporal_alarm_filtering.py
@@ -224,9 +224,6 @@ class AlarmFilterRunner(Thread):
             try:
                 post_alarm(alarm['features'], self.restapi_url, self._xauth_token)
                 LOG.info('Alarm sent - status OK')
-            # except (HTTPError, ConnectionError) as err:
-            #    LOG.exception('Failed sending alarm! Error: %s', str(err))
-            #    LOG.error('Data: %s', str(alarm['features']))
             except (HTTPError, ConnectionError):
                 LOG.exception('Failed sending alarm!')
                 LOG.error('Data: %s', str(alarm['features']))

--- a/activefires_pp/tests/conftest.py
+++ b/activefires_pp/tests/conftest.py
@@ -34,6 +34,11 @@ geojson_file_pattern_alarms: sos_{start_time:%Y%m%d_%H%M%S}_{id:d}.geojson
 fire_alarms_dir: /path/where/the/filtered/alarms/will/be/stored
 
 restapi_url: "https://xxx.smhi.se:xxxx"
+
+time_and_space_thresholds:
+  hour_threshold: 6
+  long_fires_threshold_km: 1.2
+  spatial_threshold_km: 0.8
 """
 
 TEST_YAML_TOKENS = """xauth_tokens:

--- a/activefires_pp/tests/test_geojson_utils.py
+++ b/activefires_pp/tests/test_geojson_utils.py
@@ -20,11 +20,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Test the Geojson utillities.
-"""
+"""Test the Geojson utillities."""
 
 from activefires_pp.geojson_utils import read_geojson_data
-from activefires_pp.geojson_utils import get_recent_geojson_files
+from activefires_pp.geojson_utils import get_geojson_files_in_observation_time_order
 from activefires_pp.geojson_utils import store_geojson_alarm
 from trollsift import Parser
 
@@ -32,7 +31,16 @@ from datetime import datetime
 import pytest
 import logging
 
-TEST_GEOJSON_FILE_CONTENT = """{"type": "FeatureCollection", "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.562864, 67.341919]}, "properties": {"power": 1.62920368, "tb": 325.2354126, "confidence": 8, "observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.56245, 67.347328]}, "properties": {"power": 3.40044808, "tb": 329.46963501, "confidence": 8, "observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.555086, 67.343231]}, "properties": {"power": 6.81757641, "tb": 334.62347412, "confidence": 8, "observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}}]}"""
+TEST_GEOJSON_FILE_CONTENT = """{"type": "FeatureCollection", "features":
+[{"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.562864, 67.341919]},
+"properties": {"power": 1.62920368, "tb": 325.2354126, "confidence": 8,
+"observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}},
+{"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.56245, 67.347328]},
+"properties": {"power": 3.40044808, "tb": 329.46963501, "confidence": 8,
+"observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}},
+{"type": "Feature", "geometry": {"type": "Point", "coordinates": [23.555086, 67.343231]},
+"properties": {"power": 6.81757641, "tb": 334.62347412, "confidence": 8,
+"observation_time": "2022-06-29T14:01:08.850000", "platform_name": "NOAA-20"}}]}"""
 
 
 @pytest.fixture
@@ -116,27 +124,27 @@ def test_read_and_get_geojson_data_from_empty_file(caplog, fake_empty_geojson_fi
     assert log_output in caplog.text
 
 
-def test_get_recent_geojson_files(fake_past_detections_dir):
-    """Test getting the list of recent geojson files."""
+def test_get_geojson_files_in_observation_time_order(fake_past_detections_dir):
+    """Test getting the list of geojson files ordered by observation time - most recent file first."""
     starttime = datetime(2021, 6, 18, 12, 0)
     endtime = datetime(2021, 6, 19, 0, 30)
     # geojson_file_pattern_alarms: sos_{start_time:%Y%m%d_%H%M%S}_{id:d}.geojson
     pattern = "sos_{start_time:%Y%m%d_%H%M%S}_{id:d}.geojson"
 
-    recent = get_recent_geojson_files(fake_past_detections_dir, pattern, (starttime, endtime))
+    recent = get_geojson_files_in_observation_time_order(fake_past_detections_dir, pattern, (starttime, endtime))
     assert set(recent) == {'sos_20210618_124819_0.geojson', 'sos_20210619_000651_1.geojson',
                            'sos_20210619_000651_0.geojson'}
 
     starttime = datetime(2021, 6, 18, 12, 0)
     endtime = datetime(2021, 6, 19, 12, 0)
-    recent = get_recent_geojson_files(fake_past_detections_dir, pattern, (starttime, endtime))
+    recent = get_geojson_files_in_observation_time_order(fake_past_detections_dir, pattern, (starttime, endtime))
 
     assert set(recent) == {'sos_20210618_124819_0.geojson', 'sos_20210619_000651_1.geojson',
                            'sos_20210619_000651_0.geojson', 'sos_20210619_005803_0.geojson'}
 
     starttime = datetime(2022, 6, 18, 12, 0)
     endtime = datetime(2022, 6, 19, 12, 0)
-    recent = get_recent_geojson_files(fake_past_detections_dir, pattern, (starttime, endtime))
+    recent = get_geojson_files_in_observation_time_order(fake_past_detections_dir, pattern, (starttime, endtime))
     assert len(recent) == 0
 
 

--- a/activefires_pp/tests/test_spatiotemporal_alarm_filtering.py
+++ b/activefires_pp/tests/test_spatiotemporal_alarm_filtering.py
@@ -26,6 +26,7 @@ import pytest
 from unittest.mock import patch
 import pathlib
 import json
+import logging
 from activefires_pp.geojson_utils import read_geojson_data
 from activefires_pp.spatiotemporal_alarm_filtering import create_alarms_from_fire_detections
 from activefires_pp.spatiotemporal_alarm_filtering import join_fire_detections
@@ -262,8 +263,10 @@ def test_create_alarms_from_fire_detections(fake_past_detections_dir):
 
     pattern = "sos_{start_time:%Y%m%d_%H%M%S}_{id:d}.geojson"
     # Default distance threshold but disregarding past alarms:
+    space_time_threshold = {'hour_threshold': 0.0,
+                            'long_fires_threshold_km': 1.2}
     alarms = create_alarms_from_fire_detections(json_test_data, fake_past_detections_dir,
-                                                pattern, 1.2, 0.0)
+                                                pattern, space_time_threshold)
     assert len(alarms) == 3
     assert alarms[0]['features']['geometry']['coordinates'] == [16.247334, 57.172443]
     assert alarms[0]['features']['properties']['power'] == 5.85325146
@@ -286,9 +289,10 @@ def test_create_alarms_from_fire_detections(fake_past_detections_dir):
     assert alarms[2]['features']['properties']['tb'] == 310.37322998
     assert alarms[2]['features']['properties']['observation_time'] == '2021-06-19T02:58:45.700000+02:00'
 
-    # Default thresholds (distance=1.2km, time-interval=6hours):
+    space_time_threshold = {'hour_threshold': 6.0,
+                            'long_fires_threshold_km': 1.2}
     alarms = create_alarms_from_fire_detections(json_test_data, fake_past_detections_dir,
-                                                pattern)
+                                                pattern, space_time_threshold)
 
     assert len(alarms) == 1
     assert alarms[0]['features']['geometry']['coordinates'] == [16.249069, 57.156235]
@@ -298,10 +302,10 @@ def test_create_alarms_from_fire_detections(fake_past_detections_dir):
     assert alarms[0]['features']['properties']['tb'] == 310.37322998
     assert alarms[0]['features']['properties']['observation_time'] == '2021-06-19T02:58:45.700000+02:00'
 
-    # Default time-interval(=6hours) threshold but smaller distance threshold
-    # (the threshold used to split larger fires):
+    space_time_threshold = {'hour_threshold': 6.0,
+                            'long_fires_threshold_km': 0.6}
     alarms = create_alarms_from_fire_detections(json_test_data, fake_past_detections_dir,
-                                                pattern, 0.6)
+                                                pattern, space_time_threshold)
 
     assert len(alarms) == 2
     assert alarms[0]['features']['geometry']['coordinates'] == [16.242212, 57.157097]
@@ -318,8 +322,10 @@ def test_create_alarms_from_fire_detections(fake_past_detections_dir):
     assert alarms[1]['features']['properties']['tb'] == 310.37322998
     assert alarms[1]['features']['properties']['observation_time'] == '2021-06-19T02:58:45.700000+02:00'
 
+    space_time_threshold = {'hour_threshold': 16.0,
+                            'long_fires_threshold_km': 1.2}
     alarms = create_alarms_from_fire_detections(json_test_data, fake_past_detections_dir,
-                                                pattern, 1.2, 16.0)
+                                                pattern, space_time_threshold)
 
     assert len(alarms) == 1
     assert alarms[0]['features']['geometry']['coordinates'] == [16.249069, 57.156235]
@@ -329,8 +335,9 @@ def test_create_alarms_from_fire_detections(fake_past_detections_dir):
     assert alarms[0]['features']['properties']['tb'] == 310.37322998
     assert alarms[0]['features']['properties']['observation_time'] == '2021-06-19T02:58:45.700000+02:00'
 
+    space_time_threshold = {}
     alarms = create_alarms_from_fire_detections(json_test_data, fake_past_detections_dir,
-                                                pattern, 1.2)
+                                                pattern, space_time_threshold)
 
     assert len(alarms) == 1
     assert alarms[0]['features']['geometry']['coordinates'] == [16.249069, 57.156235]
@@ -377,7 +384,10 @@ def test_alarm_filter_runner_init(setup_comm,
                                     'publish_topic': '/VIIRS/L2/Fires/PP/SOSAlarm',
                                     'geojson_file_pattern_alarms': 'sos_{start_time:%Y%m%d_%H%M%S}_{id:d}.geojson',
                                     'fire_alarms_dir': '/path/where/the/filtered/alarms/will/be/stored',
-                                    'restapi_url': 'https://xxx.smhi.se:xxxx'}
+                                    'restapi_url': 'https://xxx.smhi.se:xxxx',
+                                    'time_and_space_thresholds': {'hour_threshold': 6,
+                                                                  'long_fires_threshold_km': 1.2,
+                                                                  'spatial_threshold_km': 0.8}}
 
 
 @pytest.mark.usefixtures("fake_token_file")
@@ -456,3 +466,50 @@ def test_alarm_filter_runner_call_spatio_temporal_alarm_filtering_no_alarms(crea
     dummy_msg = None
     result = alarm_runner.spatio_temporal_alarm_filtering(dummy_msg)
     assert result is None
+
+
+@patch('activefires_pp.spatiotemporal_alarm_filtering.AlarmFilterRunner._setup_and_start_communication')
+def test_check_and_set_threshold_threshold_okay(setup_comm,
+                                                monkeypatch, fake_yamlconfig_file,
+                                                fake_token_file, caplog):
+    """Test checking and setting a spatio-temporal threshold - threshold accepted."""
+    from activefires_pp.config import read_config
+
+    monkeypatch.setenv("FIREALARMS_XAUTH_FILEPATH", str(fake_token_file))
+
+    alarm_runner = AlarmFilterRunner(str(fake_yamlconfig_file))
+    config = read_config(alarm_runner.configfile)
+
+    thr_type = 'hour_threshold'
+    alarm_runner.time_and_space_thresholds[thr_type] = None
+    alarm_runner._log_message_per_threshold = {thr_type:
+                                               ('okay message - hours: %3.1f', 'error message - hours'), }
+
+    with caplog.at_level(logging.INFO):
+        alarm_runner._check_and_set_threshold(thr_type, config)
+
+    log_output = 'okay message - hours: 6.0'
+    assert log_output in caplog.text
+    assert alarm_runner.time_and_space_thresholds[thr_type] == 6.0
+
+
+@patch('activefires_pp.spatiotemporal_alarm_filtering.AlarmFilterRunner._setup_and_start_communication')
+def test_check_and_set_threshold_wrong_threshold(setup_comm,
+                                                 monkeypatch, fake_yamlconfig_file,
+                                                 fake_token_file, caplog):
+    """Test checking and setting a spatio-temporal threshold - wrong threshold name."""
+    from activefires_pp.config import read_config
+
+    monkeypatch.setenv("FIREALARMS_XAUTH_FILEPATH", str(fake_token_file))
+
+    alarm_runner = AlarmFilterRunner(str(fake_yamlconfig_file))
+    config = read_config(alarm_runner.configfile)
+
+    thr_type = 'unknown_threshold'
+    alarm_runner._log_message_per_threshold = {thr_type:
+                                               ('okay message - hours: %3.1f', 'error message - hours'), }
+    with pytest.raises(OSError) as exec_info:
+        alarm_runner._check_and_set_threshold(thr_type, config)
+
+    expected = alarm_runner._log_message_per_threshold[thr_type][1]
+    assert str(exec_info.value) == expected

--- a/examples/spatio_temporal_alarm_filtering.yaml
+++ b/examples/spatio_temporal_alarm_filtering.yaml
@@ -9,3 +9,9 @@ fire_alarms_dir: /path/where/the/filtered/alarms/will/be/stored
 #geojson_fires_dir: /path/to/where/the/filtered/detections/are/stored
 
 restapi_url: "https://xxx.smhi.se:xxxx"
+
+# Thresholds in time and space:
+time_and_space_thresholds:
+  hour_threshold: 6
+  long_fires_threshold_km: 1.2
+  spatial_threshold_km: 0.8


### PR DESCRIPTION
This PR makes the three space-time thresholds configurable via a yaml config file:
```
# Thresholds in time and space:
time_and_space_thresholds:
  hour_threshold: 6
  long_fires_threshold_km: 1.2
  spatial_threshold_km: 0.8
```


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
