### PR TITLE
Allow specify products to notify

### DIFF
--- a/activefires_pp/fire_notifications.py
+++ b/activefires_pp/fire_notifications.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021, 2022 Adam Dybbroe
+# Copyright (c) 2021 - 2023 Adam Dybbroe
 
 # Author(s):
 
@@ -20,8 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Creating and sending notifications for detected forest fires.
-"""
+"""Creating and sending notifications for detected forest fires."""
 
 import socket
 from netrc import netrc
@@ -56,8 +55,10 @@ LOG = logging.getLogger(__name__)
 
 
 class RecipientDataStruct(object):
-    def __init__(self):
+    """A data structure to control the list of configured recipients."""
 
+    def __init__(self):
+        """Initialize the recipient data structure."""
         self.recipients_with_attachment = []
         self.recipients_without_attachment = []
         self.recipients_all = []
@@ -140,7 +141,6 @@ class EndUserNotifier(Thread):
 
     def _set_options_from_config(self, config):
         """From the configuration on disk set the option dictionary, holding all metadata for processing."""
-
         for item in config:
             self.options[item] = config[item]
 
@@ -184,6 +184,12 @@ class EndUserNotifier(Thread):
                     LOG.debug("Message type not supported: %s", str(msg.type))
                     continue
 
+                product_name = msg.data.get('product')
+                product_list = self.options.get('products')
+                if product_list and product_name and product_name not in product_list:
+                    LOG.info('Product %s will not generate a notification!', product_name)
+                    continue
+
                 output_msg = self.notify_end_users(msg)
                 if output_msg:
                     LOG.debug("Sending message: %s", str(output_msg))
@@ -218,7 +224,6 @@ class EndUserNotifier(Thread):
 
     def _send_notifications_with_attachments(self, server, recipients, full_message, filename, platform_name):
         """Send notifications with attachments."""
-
         notification = MIMEMultipart()
         notification['From'] = self.sender
         if platform_name:
@@ -252,7 +257,6 @@ class EndUserNotifier(Thread):
 
     def _send_notifications_without_attachments(self, server, recipients, sub_messages, platform_name):
         """Send notifications without attachments."""
-
         for submsg in sub_messages:
             notification = MIMEMultipart()
             notification['From'] = self.sender

--- a/activefires_pp/fire_notifications.py
+++ b/activefires_pp/fire_notifications.py
@@ -184,10 +184,7 @@ class EndUserNotifier(Thread):
                     LOG.debug("Message type not supported: %s", str(msg.type))
                     continue
 
-                product_name = msg.data.get('product')
-                product_list = self.options.get('products')
-                if product_list and product_name and product_name not in product_list:
-                    LOG.info('Product %s will not generate a notification!', product_name)
+                if not self._product_name_supported(msg):
                     continue
 
                 output_msg = self.notify_end_users(msg)
@@ -196,6 +193,16 @@ class EndUserNotifier(Thread):
                     self.publisher.send(str(output_msg))
                 else:
                     LOG.debug("No message to send")
+
+    def _product_name_supported(self, incoming_msg):
+        """Check that the product name is supported via the configuration."""
+        product_name = incoming_msg.data.get('product')
+        product_list = self.options.get('products')
+        if product_list and product_name and product_name not in product_list:
+            LOG.info('Product %s will not generate a notification!', product_name)
+            return False
+
+        return True
 
     def notify_end_users(self, msg):
         """Send notifications to configured end users (mail and text messages)."""

--- a/activefires_pp/tests/test_fire_notifications.py
+++ b/activefires_pp/tests/test_fire_notifications.py
@@ -40,6 +40,10 @@ NAT_CONFIG = """
 publish_topic: VIIRS/L2/MSB/National
 subscribe_topics: VIIRS/L2/Fires/PP/National
 
+products:
+  - afimg
+  - afimg_some_other_geoid
+
 smtp_server: smtp.mydomain.se
 
 domain: mydomain.se
@@ -137,7 +141,9 @@ class TestNotifyEndUsers(unittest.TestCase):
 
         expected = {'publish_topic': 'VIIRS/L2/MSB/National',
                     'subscribe_topics': ['VIIRS/L2/Fires/PP/National'],
-                    'smtp_server': 'smtp.mydomain.se', 'domain': 'mydomain.se', 'sender': 'active-fires@mydomain.se',
+                    'products': ['afimg', 'afimg_some_other_geoid'],
+                    'smtp_server': 'smtp.mydomain.se',
+                    'domain': 'mydomain.se', 'sender': 'active-fires@mydomain.se',
                     'recipients': ['recipient1@recipients.se', 'recipient2@recipients.se', 'recipient3@recipients.se'],
                     'recipients_attachment': ['recipient1@recipients.se', 'recipient2@recipients.se'],
                     'subject': 'My subject', 'max_number_of_fires_in_sms': 3,

--- a/activefires_pp/tests/test_messaging.py
+++ b/activefires_pp/tests/test_messaging.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021, 2022, 2023 Adam.Dybbroe
+# Copyright (c) 2021 - 2023 Adam.Dybbroe
 
 # Author(s):
 
-#   Adam.Dybbroe <a000680@c21856.ad.smhi.se>
+#   Adam Dybbroe <Firstname.Lastname at smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/examples/fire_notifier.yaml
+++ b/examples/fire_notifier.yaml
@@ -2,6 +2,10 @@
 publish_topic: VIIRS/L2/MSB/National
 subscribe_topics: VIIRS/L2/Fires/PP/National
 
+products:
+  - afimg
+  - afimg_some_other_geoid
+
 smtp_server: smtp.mydomain.se
 
 domain: mydomain.se


### PR DESCRIPTION
This PR adds an option to allow specifying in the configuration which (national) products should trigger notifications

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
