### PR TITLE
Add filter to discard spurious detections with very low FRP and high TB(I-Band 4)

### DIFF
--- a/activefires_pp/post_processing.py
+++ b/activefires_pp/post_processing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021 - 2023 Adam.Dybbroe
+# Copyright (c) 2021 - 2024 Adam.Dybbroe
 
 # Author(s):
 
@@ -151,7 +151,7 @@ class ActiveFiresShapefileFiltering(object):
         return np.repeat(obstime.replace(tzinfo=None) + obstime_offset,
                          len(self._afdata)).astype(np.datetime64)
 
-    def fires_filtering(self, shapefile, start_geometries_index=1, inside=True):
+    def fires_shapefile_filtering(self, shapefile, start_geometries_index=1, inside=True):
         """Remove fires outside National borders or filter out potential false detections.
 
         If *inside* is True the filtering will keep those detections that are inside the polygon.
@@ -554,17 +554,20 @@ class ActiveFiresPostprocessing(Thread):
         out_filepath = os.path.join(self.output_dir, pout.compose(fmda))
         logger.debug("Output file path = %s", out_filepath)
 
+        # Remove spurious detections:
+        # FIXME!
+
         # National filtering:
-        af_shapeff.fires_filtering(self.shp_borders)
+        af_shapeff.fires_shapefile_filtering(self.shp_borders)
 
         # Metadata should be transfered here!
         afdata_ff = af_shapeff.get_af_data()
 
         if len(afdata_ff) > 0:
             logger.debug("Doing the fires filtering: shapefile-mask = %s", str(self.shp_filtermask))
-            af_shapeff.fires_filtering(self.shp_filtermask, start_geometries_index=0, inside=False)
+            af_shapeff.fires_shapefile_filtering(self.shp_filtermask, start_geometries_index=0, inside=False)
             afdata_ff = af_shapeff.get_af_data()
-            logger.debug("After fires_filtering: Number of fire detections left: %d", len(afdata_ff))
+            logger.debug("After fires_shapefile_filtering: Number of fire detections left: %d", len(afdata_ff))
 
         return afdata_ff
 

--- a/activefires_pp/sanity_check_detections.py
+++ b/activefires_pp/sanity_check_detections.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 def remove_spurious_detections(af_dataframe):
     """Check active fires data and return those that are not classified as spurious."""
-    spurious = (af_dataframe['tb']/af_dataframe['power'] > 1000) & (af_dataframe['tb'] > 305)
+    spurious = (af_dataframe['tb']/af_dataframe['power'] > 1000) & (af_dataframe['tb'] > 310)
     non_spurious = ~spurious
     n_spurious = len(af_dataframe[spurious])
     if n_spurious > 0:

--- a/activefires_pp/sanity_check_detections.py
+++ b/activefires_pp/sanity_check_detections.py
@@ -37,14 +37,15 @@ logger = logging.getLogger(__name__)
 def remove_spurious_detections(af_dataframe):
     """Check active fires data and return those that are not classified as spurious."""
     spurious = (af_dataframe['tb']/af_dataframe['power'] > 1000) & (af_dataframe['tb'] > 305)
-    n_spurious = len(af_dataframe[spurious is True])
+    non_spurious = ~spurious
+    n_spurious = len(af_dataframe[spurious])
     if n_spurious > 0:
         logger.info(f"Number of spurious detections filtered out = {n_spurious}")
-        for idx in range(len(af_dataframe[spurious is True])):
+        for idx in range(len(af_dataframe[spurious])):
             logger.info("({lon},{lat}): Tb4 = {tb4} FRP = {frp}".format(
-                lon=af_dataframe[spurious is True]['longitude'].values[idx],
-                lat=af_dataframe[spurious is True]['latitude'].values[idx],
-                tb4=af_dataframe[spurious is True]['tb'].values[idx],
-                frp=af_dataframe[spurious is True]['power'].values[idx]))
+                lon=af_dataframe[spurious]['longitude'].values[idx],
+                lat=af_dataframe[spurious]['latitude'].values[idx],
+                tb4=af_dataframe[spurious]['tb'].values[idx],
+                frp=af_dataframe[spurious]['power'].values[idx]))
 
-    return af_dataframe[spurious is False]
+    return af_dataframe[non_spurious]

--- a/activefires_pp/sanity_check_detections.py
+++ b/activefires_pp/sanity_check_detections.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 Adam.Dybbroe
+
+# Author(s):
+
+#   Adam.Dybbroe <a000680@c22526.ad.smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Sanity checking the active fire detections - removing spurious data points.
+
+So far the only known spurious detections are those caused by onboaud issues in
+I-band 4, due to high energy ionisizing particles. These events are frequent
+over the South atlantic magnetic anomaly, but occassionally also occur
+elsewhere on the globe, probably more frequent when the solar activity is high.
+
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def remove_spurious_detections(af_dataframe):
+    """Check active fires data and return those that are not classified as spurious."""
+    spurious = (af_dataframe['tb']/af_dataframe['power'] > 1000) & (af_dataframe['tb'] > 305)
+    n_spurious = len(af_dataframe[spurious is True])
+    if n_spurious > 0:
+        logger.info(f"Number of spurious detections filtered out = {n_spurious}")
+        for idx in range(len(af_dataframe[spurious is True])):
+            logger.info("({lon},{lat}): Tb4 = {tb4} FRP = {frp}".format(
+                lon=af_dataframe[spurious is True]['longitude'].values[idx],
+                lat=af_dataframe[spurious is True]['latitude'].values[idx],
+                tb4=af_dataframe[spurious is True]['tb'].values[idx],
+                frp=af_dataframe[spurious is True]['power'].values[idx]))
+
+    return af_dataframe[spurious is False]

--- a/activefires_pp/tests/conftest.py
+++ b/activefires_pp/tests/conftest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2022, 2023 Adam.Dybbroe
+# Copyright (c) 2022, 2023, 2024 Adam.Dybbroe
 
 # Author(s):
 
@@ -148,8 +148,8 @@ PAST_ALARMS_MONSTERAS3 = """{"features": {"geometry": {"coordinates": [16.252192
 TEST_ACTIVE_FIRES_FILEPATH = "./AFIMG_j01_d20210414_t1126439_e1128084_b17637_c20210414114130392094_cspp_dev.txt"
 TEST_ACTIVE_FIRES_FILEPATH2 = "./AFIMG_npp_d20230616_t1110054_e1111296_b60284_c20230616112418557033_cspp_dev.txt"
 TEST_ACTIVE_FIRES_FILEPATH3 = "./AFIMG_j01_d20230617_t1140564_e1142209_b28903_c20230617115513873196_cspp_dev.txt"
-
 TEST_ACTIVE_FIRES_FILEPATH4 = "./AFIMG_j01_d20230618_t0942269_e0943514_b28916_c20230618095604331171_cspp_dev.txt"
+TEST_ACTIVE_FIRES_FILEPATH5 = "./AFIMG_j02_d20231211_t0152445_e0154074_b05616_c20231211020710860273_cspp_dev.txt"
 
 
 TEST_ACTIVE_FIRES_FILE_DATA = """
@@ -256,6 +256,27 @@ TEST_ACTIVE_FIRES_FILE_DATA4 = """
   67.27209473,   20.14731216,  348.89843750,  0.375,  0.375,    8,   11.79477501
 """
 
+# Here an example with one spurious detection, with high TB in I-band 4 and very low FRP:
+TEST_ACTIVE_FIRES_FILE_DATA5 = """
+# Active Fires I-band EDR
+#
+# source: AFIMG_j02_d20231211_t0152445_e0154074_b05616_c20231211020710860273_cspp_dev.nc
+# version: CSPP Active Fires version: cspp-active-fire-noaa_1.1.0
+#
+# column 1: latitude of fire pixel (degrees)
+# column 2: longitude of fire pixel (degrees)
+# column 3: I04 brightness temperature of fire pixel (K)
+# column 4: Along-scan fire pixel resolution (km)
+# column 5: Along-track fire pixel resolution (km)
+# column 6: detection confidence ([7,8,9]->[lo,med,hi])
+# column 7: fire radiative power (MW)
+#
+# number of fire pixels: 2
+#
+  60.17847443,   -3.87098718,  295.43579102,  0.375,  0.375,    8,    0.82296646
+  57.90747833,   13.09044647,  324.07070923,  0.375,  0.375,    8,    0.11022940
+"""
+
 
 @pytest.fixture
 def fake_active_fires_file_data():
@@ -295,6 +316,16 @@ def fake_active_fires_ascii_file4(tmp_path):
     file_path = tmp_path / TEST_ACTIVE_FIRES_FILEPATH4
     with open(file_path, 'w') as fpt:
         fpt.write(TEST_ACTIVE_FIRES_FILE_DATA4)
+
+    yield file_path
+
+
+@pytest.fixture
+def fake_active_fires_ascii_file5(tmp_path):
+    """Create a fake active fires ascii file."""
+    file_path = tmp_path / TEST_ACTIVE_FIRES_FILEPATH5
+    with open(file_path, 'w') as fpt:
+        fpt.write(TEST_ACTIVE_FIRES_FILE_DATA5)
 
     yield file_path
 

--- a/activefires_pp/tests/test_fire_detection_id_handling.py
+++ b/activefires_pp/tests/test_fire_detection_id_handling.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2023 Adam.Dybbroe
+# Copyright (c) 2023, 2024 Adam.Dybbroe
 
 # Author(s):
 
@@ -28,10 +28,7 @@ from freezegun import freeze_time
 
 from activefires_pp.post_processing import ActiveFiresShapefileFiltering
 from activefires_pp.post_processing import ActiveFiresPostprocessing
-
-
-MY_FILE_PATTERN = ("AFIMG_{platform:s}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_hour:%H%M%S%f}_" +
-                   "b{orbit:s}_c{processing_time:%Y%m%d%H%M%S%f}_cspp_dev.txt")
+from activefires_pp.tests.test_utils import AF_FILE_PATTERN
 
 
 @freeze_time('2023-06-16 11:24:00')
@@ -50,7 +47,7 @@ def test_add_unique_day_id_to_detections_sameday(setup_comm, gethostname,
                                      myborders_file, mymask_file)
 
     this = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file2, timezone='GMT')
-    afdata = this.get_af_data(filepattern=MY_FILE_PATTERN, localtime=False)
+    afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     assert afpp._fire_detection_id == {'date': datetime.utcnow(), 'counter': 0}
 
@@ -79,7 +76,7 @@ def test_add_unique_day_id_to_detections_24hours_plus(setup_comm, gethostname,
     afpp._fire_detection_id = {'date': datetime(2023, 6, 16, 11, 24, 0), 'counter': 4}
 
     this = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file3, timezone='GMT')
-    afdata = this.get_af_data(filepattern=MY_FILE_PATTERN, localtime=False)
+    afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     assert afpp._fire_detection_id == {'date': datetime(2023, 6, 16, 11, 24, 0), 'counter': 4}
 
@@ -108,7 +105,7 @@ def test_add_unique_day_id_to_detections_newday_from_cache(setup_comm, gethostna
 
     this = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file4,
                                          timezone='GMT')
-    afdata = this.get_af_data(filepattern=MY_FILE_PATTERN, localtime=False)
+    afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     assert afpp._fire_detection_id == {'date': datetime(2023, 5, 1, 0, 0), 'counter': 1}
     # 2 new fire detections, so (current) ID should be raised - a new day, so id
@@ -137,7 +134,7 @@ def test_add_unique_day_id_to_detections_newday_no_cache(setup_comm, gethostname
 
     this = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file4,
                                          timezone='GMT')
-    afdata = this.get_af_data(filepattern=MY_FILE_PATTERN, localtime=False)
+    afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     assert afpp._fire_detection_id == {'date': datetime(2023, 6, 17, 23, 55), 'counter': 1}
     # 2 new fire detections, so (current) ID should be raised - a new day, so id

--- a/activefires_pp/tests/test_fires_filtering.py
+++ b/activefires_pp/tests/test_fires_filtering.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021 - 2023 Adam Dybbroe
+# Copyright (c) 2021 - 2024 Adam Dybbroe
 
 # Author(s):
 
@@ -129,6 +129,26 @@ TEST_ACTIVE_FIRES_FILE_DATA3 = """
   64.46707153,   17.65028381,  330.15390015,  0.375,  0.375,    8,    3.75669074
 """
 
+# Here an example with one spurious detection, with high TB in I-band 4 and very low FRP:
+TEST_ACTIVE_FIRES_FILE_DATA4 = """
+# Active Fires I-band EDR
+#
+# source: AFIMG_j02_d20231211_t0152445_e0154074_b05616_c20231211020710860273_cspp_dev.nc
+# version: CSPP Active Fires version: cspp-active-fire-noaa_1.1.0
+#
+# column 1: latitude of fire pixel (degrees)
+# column 2: longitude of fire pixel (degrees)
+# column 3: I04 brightness temperature of fire pixel (K)
+# column 4: Along-scan fire pixel resolution (km)
+# column 5: Along-track fire pixel resolution (km)
+# column 6: detection confidence ([7,8,9]->[lo,med,hi])
+# column 7: fire radiative power (MW)
+#
+# number of fire pixels: 2
+#
+  57.90747833,   13.09044647,  324.07070923,  0.375,  0.375,    8,    0.11022940
+  60.17847443,   -3.87098718,  295.43579102,  0.375,  0.375,    8,    0.82296646
+"""
 
 TEST_REGIONAL_MASK = {}
 TEST_REGIONAL_MASK['Bergslagen (RRB)'] = {'mask': np.array([False, False, False, False, False,

--- a/activefires_pp/tests/test_fires_filtering.py
+++ b/activefires_pp/tests/test_fires_filtering.py
@@ -172,17 +172,17 @@ def test_add_start_and_end_time_to_active_fires_data_utc(readdata, fake_active_f
 
     readdata.return_value = afdata
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
+        af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
-    assert 'starttime' in this._afdata
-    assert 'endtime' in this._afdata
-    assert this._afdata['starttime'].shape == (18,)
+    assert 'starttime' in af_shpfile_filter.afdata
+    assert 'endtime' in af_shpfile_filter.afdata
+    assert af_shpfile_filter.afdata['starttime'].shape == (18,)
 
-    assert str(this._afdata['starttime'][0]) == '2021-04-14 11:26:43.900000'
-    assert str(this._afdata['endtime'][0]) == '2021-04-14 11:28:08'
+    assert str(af_shpfile_filter.afdata['starttime'][0]) == '2021-04-14 11:26:43.900000'
+    assert str(af_shpfile_filter.afdata['endtime'][0]) == '2021-04-14 11:28:08'
 
 
 @patch('activefires_pp.post_processing._read_data')
@@ -193,49 +193,49 @@ def test_add_start_and_end_time_to_active_fires_data_localtime(readdata, fake_ac
     afdata = pd.read_csv(open_fstream, index_col=None, header=None, comment='#', names=COL_NAMES)
     readdata.return_value = afdata
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Stockholm')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Stockholm')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
+        af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
 
-    assert 'starttime' in this._afdata
-    assert 'endtime' in this._afdata
+    assert 'starttime' in af_shpfile_filter.afdata
+    assert 'endtime' in af_shpfile_filter.afdata
 
-    assert str(this._afdata['starttime'][0]) == '2021-04-14 13:26:43.900000'
-    assert str(this._afdata['endtime'][0]) == '2021-04-14 13:28:08'
+    assert str(af_shpfile_filter.afdata['starttime'][0]) == '2021-04-14 13:26:43.900000'
+    assert str(af_shpfile_filter.afdata['endtime'][0]) == '2021-04-14 13:28:08'
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Iceland')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Iceland')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
+        af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
 
-    assert 'starttime' in this._afdata
-    assert 'endtime' in this._afdata
+    assert 'starttime' in af_shpfile_filter.afdata
+    assert 'endtime' in af_shpfile_filter.afdata
 
-    assert str(this._afdata['starttime'][0]) == '2021-04-14 11:26:43.900000'
-    assert str(this._afdata['endtime'][0]) == '2021-04-14 11:28:08'
+    assert str(af_shpfile_filter.afdata['starttime'][0]) == '2021-04-14 11:26:43.900000'
+    assert str(af_shpfile_filter.afdata['endtime'][0]) == '2021-04-14 11:28:08'
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Helsinki')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Helsinki')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
+        af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
 
-    assert 'starttime' in this._afdata
-    assert 'endtime' in this._afdata
+    assert 'starttime' in af_shpfile_filter.afdata
+    assert 'endtime' in af_shpfile_filter.afdata
 
-    assert str(this._afdata['starttime'][0]) == '2021-04-14 14:26:43.900000'
-    assert str(this._afdata['endtime'][0]) == '2021-04-14 14:28:08'
+    assert str(af_shpfile_filter.afdata['starttime'][0]) == '2021-04-14 14:26:43.900000'
+    assert str(af_shpfile_filter.afdata['endtime'][0]) == '2021-04-14 14:28:08'
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Lisbon')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='Europe/Lisbon')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
+        af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=True)
 
-    assert 'starttime' in this._afdata
-    assert 'endtime' in this._afdata
+    assert 'starttime' in af_shpfile_filter.afdata
+    assert 'endtime' in af_shpfile_filter.afdata
 
-    assert str(this._afdata['starttime'][0]) == '2021-04-14 12:26:43.900000'
-    assert str(this._afdata['endtime'][0]) == '2021-04-14 12:28:08'
+    assert str(af_shpfile_filter.afdata['starttime'][0]) == '2021-04-14 12:26:43.900000'
+    assert str(af_shpfile_filter.afdata['endtime'][0]) == '2021-04-14 12:28:08'
 
 
 @patch('socket.gethostname')
@@ -375,8 +375,8 @@ def test_general_national_fires_filtering_spurious_detections(get_global_mask, s
     myborders_file = "/my/shape/file/with/country/borders"
     mymask_file = "/my/shape/file/with/polygons/to/filter/out"
 
-    this = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file5, timezone='GMT')
-    afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=fake_active_fires_ascii_file5, timezone='GMT')
+    afdata = af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
     # Add metadata to the pandas dataframe:
     fake_metadata = {'platform': 'j02',
                      'start_time': datetime(2023, 12, 11, 1, 52, 44, 500000),
@@ -466,10 +466,10 @@ def test_get_feature_collection_from_firedata_with_detection_id(readdata, setup_
     afdata = pd.read_csv(fstream, index_col=None, header=None, comment='#', names=COL_NAMES)
     readdata.return_value = afdata
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
+        afdata = af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     afdata = afdata[2::]  # Reduce to only contain the last detections!
     afdata = afpp.add_unique_day_id(afdata)
@@ -538,10 +538,10 @@ def test_get_feature_collection_from_firedata_tb_celcius(readdata, setup_comm, g
     afdata = pd.read_csv(fstream, index_col=None, header=None, comment='#', names=COL_NAMES)
     readdata.return_value = afdata
 
-    this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
+    af_shpfile_filter = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
+        afdata = af_shpfile_filter.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     afdata = afdata[2::]  # Reduce to only contain the last detections!
 

--- a/activefires_pp/tests/test_geojson_utils.py
+++ b/activefires_pp/tests/test_geojson_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2022 - 2023 Adam Dybbroe
+# Copyright (c) 2022 - 2024 Adam Dybbroe
 
 # Author(s):
 
@@ -47,7 +47,7 @@ from activefires_pp.config import read_config
 from activefires_pp.post_processing import ActiveFiresShapefileFiltering
 from activefires_pp.post_processing import ActiveFiresPostprocessing
 from activefires_pp.post_processing import COL_NAMES
-from activefires_pp.tests.test_utils import MY_FILE_PATTERN
+from activefires_pp.tests.test_utils import AF_FILE_PATTERN
 
 
 TEST_GEOJSON_FILE_CONTENT = """{"type": "FeatureCollection", "features":
@@ -252,7 +252,7 @@ def test_get_feature_collection_from_firedata(readdata, setup_comm, gethostname,
     this = ActiveFiresShapefileFiltering(filepath=myfilepath, timezone='GMT')
     with patch('os.path.exists') as mypatch:
         mypatch.return_value = True
-        afdata = this.get_af_data(filepattern=MY_FILE_PATTERN, localtime=False)
+        afdata = this.get_af_data(filepattern=AF_FILE_PATTERN, localtime=False)
 
     afdata = afpp.add_unique_day_id(afdata)
 

--- a/activefires_pp/tests/test_messaging.py
+++ b/activefires_pp/tests/test_messaging.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021-2023 Adam.Dybbroe
+# Copyright (c) 2021-2024 Adam.Dybbroe
 
 # Author(s):
 
@@ -40,7 +40,7 @@ TEST_MSG = """pytroll://VIIRS/L2/AFI/edr/2/nrk/test/polar/direct_readout file sa
 TEST_MSG_TXT = """pytroll://VIIRS/L2/AFI/edr/2/nrk/test/polar/direct_readout file safusr.t@lxserv2313.smhi.se 2023-07-05T10:27:28.821803 v1.01 application/json {"start_time": "2023-07-05T10:07:50", "end_time": "2023-07-05T10:09:15", "orbit_number": 1, "platform_name": "Suomi-NPP", "sensor": "viirs", "format": "edr", "type": "txt", "data_processing_level": "2", "variant": "DR", "orig_orbit_number": 60553, "origin": "172.29.4.164:9099", "uri": "/san1/polar_out/direct_readout/viirs_active_fires/unfiltered/AFIMG_npp_d20230705_t1007509_e1009151_b60553_c20230705102721942345_cspp_dev.txt", "uid": "AFIMG_npp_d20230705_t1007509_e1009151_b60553_c20230705102721942345_cspp_dev.txt"}"""  # noqa
 
 
-def get_fake_publiser(portnumber=1979):
+def get_fake_publisher(portnumber=1979):
     """Return a fake publisher."""
     return create_publisher_from_dict_config(dict(port=portnumber, nameservers=False))
 
@@ -61,7 +61,7 @@ def get_fake_publiser(portnumber=1979):
 #     mymask_file = "/my/shape/file/with/polygons/to/filter/out"
 
 #     afpp = ActiveFiresPostprocessing(myconfigfile, myborders_file, mymask_file)
-#     afpp.publisher = get_fake_publiser()
+#     afpp.publisher = get_fake_publisher()
 #     afpp.publisher.start()
 
 #     return afpp
@@ -111,14 +111,13 @@ def test_check_incoming_message_nc_file_exists(setup_comm, gethostname, path_exi
                                      myborders_file, mymask_file)
     afpp.filepath_detection_id_cache = False
 
-    afpp.publisher = get_fake_publiser(1979)
-    afpp.publisher.start()
-
     input_msg = Message.decode(rawstr=TEST_MSG)
     with patched_publisher() as published_messages:
+        afpp.publisher = get_fake_publisher()
+        afpp.publisher.start()
         result = afpp.check_incoming_message_and_get_filename(input_msg)
+        afpp.publisher.stop()
 
-    afpp.publisher.stop()
     assert result is None
     assert len(published_messages) == 2
     assert 'No fire detections for this granule' in published_messages[0]
@@ -148,14 +147,14 @@ def test_check_incoming_message_txt_file_exists(setup_comm, gethostname, path_ex
 
     afpp = ActiveFiresPostprocessing(fake_yamlconfig_file_post_processing,
                                      myborders_file, mymask_file)
-    afpp.publisher = get_fake_publiser(1980)
-    afpp.publisher.start()
 
     input_msg = Message.decode(rawstr=TEST_MSG_TXT)
     with patched_publisher() as published_messages:
+        afpp.publisher = get_fake_publisher(1980)
+        afpp.publisher.start()
         result = afpp.check_incoming_message_and_get_filename(input_msg)
+        afpp.publisher.stop()
 
-    afpp.publisher.stop()
     assert len(published_messages) == 0
     assert result == '/san1/polar_out/direct_readout/viirs_active_fires/unfiltered/AFIMG_npp_d20230705_t1007509_e1009151_b60553_c20230705102721942345_cspp_dev.txt'  # noqa
 
@@ -178,14 +177,14 @@ def test_check_incoming_message_txt_file_does_not_exist(setup_comm, gethostname,
 
     afpp = ActiveFiresPostprocessing(fake_yamlconfig_file_post_processing,
                                      myborders_file, mymask_file)
-    afpp.publisher = get_fake_publiser(1981)
-    afpp.publisher.start()
 
     input_msg = Message.decode(rawstr=TEST_MSG_TXT)
     with patched_publisher() as published_messages:
+        afpp.publisher = get_fake_publisher(1981)
+        afpp.publisher.start()
         result = afpp.check_incoming_message_and_get_filename(input_msg)
+        afpp.publisher.stop()
 
-    afpp.publisher.stop()
     assert len(published_messages) == 0
     assert result is None
 

--- a/activefires_pp/tests/test_messaging.py
+++ b/activefires_pp/tests/test_messaging.py
@@ -45,49 +45,6 @@ def get_fake_publisher(portnumber=1979):
     return create_publisher_from_dict_config(dict(port=portnumber, nameservers=False))
 
 
-# @pytest.fixture(scope='session')
-# @patch('os.path.exists')
-# @patch('socket.gethostname')
-# @patch('activefires_pp.post_processing.read_config')
-# @patch('activefires_pp.post_processing.ActiveFiresPostprocessing._setup_and_start_communication')
-# def fake_af_instance(setup_comm, get_config, gethostname, path_exists):
-
-#     get_config.return_value = CONFIG_EXAMPLE
-#     gethostname.return_value = "my.host.name"
-#     path_exists.return_value = True
-
-#     myconfigfile = "/my/config/file/path"
-#     myborders_file = "/my/shape/file/with/country/borders"
-#     mymask_file = "/my/shape/file/with/polygons/to/filter/out"
-
-#     afpp = ActiveFiresPostprocessing(myconfigfile, myborders_file, mymask_file)
-#     afpp.publisher = get_fake_publisher()
-#     afpp.publisher.start()
-
-#     return afpp
-
-
-# class TestCheckMessaging:
-
-#     @pytest.fixture(autouse=True)
-#     def setup_method(self, fake_af_instance):
-#         self.afpp = fake_af_instance
-
-#     def test_check_incoming_message_nc_file_exists(self):
-#         input_msg = Message.decode(rawstr=TEST_MSG)
-
-#         with patched_publisher() as published_messages:
-#             result = self.afpp.check_incoming_message_and_get_filename(input_msg)
-
-#         assert result is None
-#         assert len(published_messages) == 2
-#         assert 'No fire detections for this granule' in published_messages[0]
-#         assert 'No fire detections for this granule' in published_messages[1]
-#         assert 'VIIRS/L2/Fires/PP/National' in published_messages[0]
-#         assert 'VIIRS/L2/Fires/PP/Regional' in published_messages[1]
-#         self.afpp.publisher.stop()
-
-
 @patch('os.path.exists')
 @patch('socket.gethostname')
 @patch('activefires_pp.post_processing.ActiveFiresPostprocessing._setup_and_start_communication')

--- a/activefires_pp/tests/test_utils.py
+++ b/activefires_pp/tests/test_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2021, 2022, 2023 Adam.Dybbroe
+# Copyright (c) 2021, 2022, 2023, 2024 Adam.Dybbroe
 
 # Author(s):
 
@@ -34,7 +34,7 @@ from activefires_pp.utils import json_serial
 NATIONAL_TEST_MESSAGE = """pytroll://VIIRS/L2/Fires/PP/National file safusr.u@lxserv1043.smhi.se 2021-04-19T11:16:49.519087 v1.01 application/json {"start_time": "2021-04-16T12:29:53", "end_time": "2021-04-16T12:31:18", "orbit_number": 1, "platform_name": "NOAA-20", "sensor": "viirs", "data_processing_level": "2", "variant": "DR", "orig_orbit_number": 17666, "uri": "ssh://lxserv1043.smhi.se//san1/polar_out/direct_readout/viirs_active_fires/filtered/AFIMG_j01_d20210416_t122953.geojson", "uid": "AFIMG_j01_d20210416_t122953.geojson", "type": "GEOJSON-filtered", "format": "geojson", "product": "afimg"}"""  # noqa
 
 
-MY_FILE_PATTERN = ("AFIMG_{platform:s}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_hour:%H%M%S%f}_" +
+AF_FILE_PATTERN = ("AFIMG_{platform:s}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_hour:%H%M%S%f}_" +
                    "b{orbit:s}_c{processing_time:%Y%m%d%H%M%S%f}_cspp_dev.txt")
 
 


### PR DESCRIPTION
This PR add a sanity check on the Active Fires data so as to remove any spurious detections where the I-band 4 TB is very high but the M-band based FRP is very low. These data indicate a glitch onboard known to affect the I-Band number 4 over the SAA (South Atlantic magnetic Anamoly) zone, but also can happen elsewhere. See figure below.

The filtering is applied after the national shapefile filtering.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Below is an example of known errors that is supposed to be filtered out with the new check.

![frp_vs_tb4_viirs_satellites_2023_2024_nightime](https://github.com/adybbroe/activefires-pp/assets/169069/deb9b8c9-79a6-4a82-8104-520bf3a4ebef)


The points far to the right (TB=367 K - saturation) is from the outgassing event of NOAA-21 end of February 2024

The new sanity-check introduced in this PR will reject detections as spurious where the TB(I-band 4)/FRP is greater than 1000 and the TB(I-band 4) is greater than 310 K. 